### PR TITLE
Admin mode: preview before PR, clickable PR link, write edits locally

### DIFF
--- a/.notes/admin-mode.md
+++ b/.notes/admin-mode.md
@@ -1,0 +1,172 @@
+# Admin mode (in-app editor + GitHub PR)
+
+A hidden admin mode lets you edit the rendered HTML in place — fix
+letters, move perush blocks (Gur Arye, Rashi notes, ...) around —
+and submit the change as a Pull Request to the source repo.
+
+This file documents both the user-facing flow and the internal
+plumbing. The same feature exists in `learnTanahApp`; the two apps
+are kept byte-identical except for `UpdateConfig.repo`.
+
+## One-time setup (per repo, on GitHub)
+
+Do this once for both `davinob/learnTorahApp` and `davinob/learnTanahApp`.
+
+1. **Protect `master`**: Settings -> Branches -> Add rule for `master`:
+   - Require a pull request before merging.
+   - Restrict who can push to matching branches -> only you (or no one).
+2. **Create a fine-grained PAT**: github.com -> Settings -> Developer
+   settings -> Personal access tokens -> Fine-grained tokens -> Generate.
+   - Resource owner: `davinob`.
+   - Repository access: **Only select repositories** ->
+     `learnTorahApp`, `learnTanahApp` (or one PAT per repo if you
+     prefer; the app uses one token per app).
+   - Repository permissions:
+     - Contents: **Read and write**
+     - Pull requests: **Read and write**
+     - Metadata: **Read-only**
+   - Expiration: pick a value you're comfortable with (e.g. 90 days).
+3. Copy the token (starts with `github_pat_...`); you only see it once.
+
+With `master` protected, the token cannot push to `master` even by
+mistake. The worst case if a device is lost is unwanted PRs, which
+you can close — and the token can be revoked from GitHub in one click.
+
+## One-time setup (in the app, per device)
+
+1. Open the app.
+2. **Tap 5 times quickly (within 1.5 seconds) in the very top
+   100px of the screen** (the status-bar margin / banner area).
+   Long-press is intercepted by Android's WebView text selection,
+   so we use a tap burst on a small invisible hot zone instead.
+3. The first time, you set an **admin passphrase** (min 6 chars).
+   On every subsequent unlock you'll be asked for that passphrase.
+4. The page reloads in admin mode — a red **ADMIN** badge appears
+   top-left and a toolbar appears at the bottom.
+5. Tap the gear icon in the toolbar -> paste your GitHub PAT ->
+   Save -> Test token. You should see "OK" and the repo name.
+
+## Editing flow
+
+In admin mode:
+
+- Tap inside any pasuk to **type / fix letters** (it's contentEditable).
+- Gur Arye spans stay collapsed exactly like normal mode — open them
+  via their `[N]` footnote marker. When opened, they get a thin
+  green dotted outline so you can spot them.
+- To **move** a perush block (rashi, gurarie, onkelos, etc.):
+  1. Tap **Select: OFF** on the toolbar so it turns green and reads
+     **Select: ON**.
+  2. Tap the block you want to move. It gets a dashed yellow outline.
+  3. Tap **Cut** (or **Copy**). The toolbar flashes "Cut. Tap target
+     block to paste after it." and every block on the page gets a
+     thin blue dashed outline — you are now in **paste mode**.
+  4. Tap the block after which the clipboard should be inserted.
+     The block is pasted right below the target, paste mode ends.
+  - On a desktop browser you can also hold **Shift** while clicking
+    a block instead of toggling Select.
+- Toolbar buttons:
+  - **Select: OFF/ON**: toggle block-selection mode (mobile-friendly
+    replacement for shift-click).
+  - **Cut** / **Copy**: clipboard the selected block, then enter
+    paste mode (next block tap pastes after it).
+  - **Undo / Redo**: in-memory snapshot stack (~100 deep).
+  - **Discard**: reload the page from disk, throwing away edits.
+  - **Submit PR**: prompts for a short title, then opens a PR.
+  - Gear: open admin settings (token, sign out).
+  - **X**: exit admin mode (go back to read-only).
+- All in-page modals can be dismissed by tapping the dark backdrop
+  outside the white card (or pressing Escape on a desktop keyboard),
+  so a stuck modal will never block the UI.
+
+When you tap Submit, the app:
+1. Asks GitHub for `master` HEAD's SHA.
+2. Creates a blob with your edited file content.
+3. Creates a tree based on `master` overriding that one file.
+4. Creates a commit pointing at the new tree.
+5. Creates a branch `admin-edit/<timestamp>-<slug>` pointing at the commit.
+6. Opens a PR from that branch into `master`.
+7. Shows you the PR URL.
+
+You then review and merge on desktop as usual.
+
+## Test plan (run once after setup)
+
+For each app (`learnTorahApp`, `learnTanahApp`):
+
+1. `flutter pub get`
+2. Run on iOS simulator and on an Android device.
+3. Tap 5 times quickly in the top 100px banner area, set passphrase, paste PAT, hit Test token.
+4. Open Bereshit/1.html (or Yehoshua/1.html for Tanah).
+5. Add an extra space inside a Hebrew word, then **Submit PR**.
+   Verify a PR appears at github.com/davinob/<repo>/pulls.
+6. Close the PR.
+7. Repeat with a Gur Arye span: tap **Select: OFF** to turn it
+   ON, tap the green-bordered gurarie span, then Down/Paste it
+   into the next pasuk's Rashi block. Submit PR and verify the
+   span (and its `[N]` marker) moved correctly in the diff.
+8. Verify `master` was NOT pushed to directly.
+9. Exit admin mode (X button) and confirm the toolbar is gone
+   and editing no longer triggers.
+
+## Files added / changed in this app
+
+- `assets/html/js/admin.js` — editor toolbar, contentEditable, JS bridge calls.
+- `assets/html/css/admin.css` — toolbar + selection styles.
+- `assets/html/**/*.html` — `<link>` + `<script>` tags injected by
+  `scripts/inject_admin_assets.py` (idempotent; safe to re-run).
+- `lib/admin/admin_storage.dart` — secure storage of token + passphrase hash.
+- `lib/admin/github_pr_service.dart` — the 7-step PR flow.
+- `lib/admin/admin_settings_screen.dart` — token entry + test + sign out.
+- `lib/admin/admin_bridge.dart` — JS bridge handler dispatching to the above.
+- `lib/main.dart` — registers the AdminBridge on the WebView, holds a
+  navigatorKey so the bridge can push routes.
+- `lib/update_service.dart` — copies `css/admin.css` and `js/admin.js`
+  into the local cache; manifest version bumped to 4 to force a re-copy.
+- `pubspec.yaml` — `flutter_secure_storage: ^9.2.2`.
+- `scripts/inject_admin_assets.py` — one-off (and idempotent) injector.
+
+## Keeping the two apps in sync
+
+The two apps share the **same** admin code. To prevent drift:
+
+- `assets/html/js/admin.js`, `assets/html/css/admin.css`, every
+  file under `lib/admin/`, and `scripts/inject_admin_assets.py`
+  should be byte-identical between the two apps.
+- The only intentional difference is `UpdateConfig.repo` in
+  `lib/update_service.dart` (`learnTorahApp` vs `learnTanahApp`).
+- Whenever you change anything admin-related in one app, copy it
+  over to the other:
+
+  ```bash
+  cp learnTorahApp/lib/admin/*.dart   learnTanahApp/lib/admin/
+  cp learnTorahApp/assets/html/js/admin.js   learnTanahApp/assets/html/js/admin.js
+  cp learnTorahApp/assets/html/css/admin.css learnTanahApp/assets/html/css/admin.css
+  cp learnTorahApp/scripts/inject_admin_assets.py learnTanahApp/scripts/inject_admin_assets.py
+  ```
+
+  Then re-run the injector in the target app if you added new HTML
+  files there:
+
+  ```bash
+  cd learnTanahApp && python3 scripts/inject_admin_assets.py
+  ```
+
+## Risks and known limitations
+
+- **Token leakage if device is lost** — token is stored in
+  `flutter_secure_storage` (Keychain on iOS, EncryptedSharedPrefs on
+  Android), but if the device is unlocked an attacker could open the
+  app and exfiltrate. Mitigation: `master` is branch-protected, and
+  the token can be revoked instantly on GitHub.
+- **Stale local copy vs. remote** — the PR is always based on the
+  current `master` HEAD, so a stale local copy still produces a clean
+  diff against `master`. If `master` moved between your sync and your
+  edit, the PR may need a manual rebase on desktop.
+- **HTML serialization** — submitting uses `document.documentElement
+  .outerHTML`. The browser may re-serialize attribute quoting (e.g.
+  `'` -> `"`) which produces noisy first-time diffs on a file. After
+  a file's first PR, subsequent diffs are clean.
+- **Multi-file edits in one session** — currently, navigating to
+  another file in admin mode does not preserve unsaved edits across
+  pages. Submit before navigating.

--- a/assets/html/css/admin.css
+++ b/assets/html/css/admin.css
@@ -1,0 +1,303 @@
+/* ============================================================
+   Admin editor styles. Loaded on every page; only takes effect
+   when admin.js sets up the toolbar (i.e. localStorage.adminMode).
+   ============================================================ */
+
+#adminToolbar {
+	position: fixed;
+	bottom: 0;
+	left: 0;
+	right: 0;
+	z-index: 99999;
+	background: #1f2937;
+	color: #f3f4f6;
+	padding: 6px 8px;
+	display: flex;
+	flex-wrap: wrap;
+	gap: 4px;
+	align-items: center;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+	font-size: 13px;
+	box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.3);
+	direction: ltr;
+}
+
+#adminToolbar button {
+	background: #374151;
+	color: #f3f4f6;
+	border: 1px solid #4b5563;
+	border-radius: 4px;
+	padding: 4px 8px;
+	font-size: 12px;
+	cursor: pointer;
+	min-height: 32px;
+}
+
+#adminToolbar button:hover {
+	background: #4b5563;
+}
+
+#adminToolbar button:active {
+	background: #6b7280;
+}
+
+#adminToolbar button.admin-toggle-on {
+	background: #047857;
+	border-color: #10b981;
+	color: #ecfdf5;
+}
+
+#adminToolbar button.admin-toggle-on:hover {
+	background: #059669;
+}
+
+/* When select-mode is on, hint that taps on blocks will select them. */
+body.admin-select-mode .newPassuk * {
+	cursor: crosshair;
+}
+
+/* When paste-mode is on, hint that the next tap will paste exactly
+   where the finger lands (the cursor becomes a copy marker). */
+body.admin-paste-mode .newPassuk,
+body.admin-paste-mode .newPassuk * {
+	cursor: copy;
+}
+body.admin-paste-mode .newPassuk {
+	outline: 1px dashed #60a5fa;
+	outline-offset: 2px;
+}
+
+#adminSelectionLabel {
+	margin-right: 6px;
+	font-weight: 600;
+	color: #fbbf24;
+	min-width: 140px;
+}
+
+#adminFlash {
+	margin-left: auto;
+	color: #34d399;
+	font-weight: 600;
+	opacity: 0;
+	transition: opacity 0.3s ease;
+}
+
+#adminBadge {
+	position: fixed;
+	top: 4px;
+	left: 4px;
+	z-index: 99998;
+	background: #dc2626;
+	color: #fff;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+	font-size: 10px;
+	font-weight: 700;
+	padding: 2px 6px;
+	border-radius: 3px;
+	letter-spacing: 1px;
+	pointer-events: none;
+	opacity: 0.85;
+}
+
+.admin-selected {
+	outline: 2px dashed #f59e0b !important;
+	outline-offset: 2px;
+	background-color: rgba(254, 243, 199, 0.35) !important;
+}
+
+/* In admin mode we do NOT force gurarie spans visible — they stay
+   collapsed exactly like in normal mode. The user opens them via the
+   normal `[N]` footnote marker, then can select / cut them. We just
+   add a thin dotted outline around the (visible) gurarie content so
+   it's obvious which block will be picked. */
+body.admin-active .gurarie:not([style*="display:none"]):not([style*="display: none"]) {
+	background-color: rgba(167, 243, 208, 0.18);
+	outline: 1px dotted #10b981;
+	outline-offset: 1px;
+}
+
+/* Lift the toolbar above any z-stacked content inside the page. */
+#adminToolbar, #adminBadge {
+	-webkit-user-select: none;
+	user-select: none;
+}
+
+/* Reserve space at the bottom so the toolbar doesn't overlap text. */
+body.admin-active {
+	padding-bottom: 80px;
+	/* Block the Android long-press text-selection chrome. That popup
+	   ("Translate / Copy / Share / Select all") causes the WebView to
+	   lose focus and gets re-instantiated by flutter_inappwebview,
+	   which reloads the page and wipes our edits + clipboard. We don't
+	   want it because we have our own block-selection mechanism. */
+	-webkit-touch-callout: none !important;
+	-webkit-user-select: none !important;
+	user-select: none !important;
+}
+
+/* The contentEditable .newPassuk regions still need to accept text input
+   for letter fixing, so re-enable selection inside them. */
+body.admin-active .newPassuk[contenteditable] {
+	-webkit-user-select: text !important;
+	user-select: text !important;
+}
+
+/* In-page modal (used because WebView prompt()/alert() handling
+   varies between Android, iOS, and webview implementations). */
+#adminModal {
+	position: fixed;
+	inset: 0;
+	background: rgba(0, 0, 0, 0.55);
+	z-index: 100000;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+	direction: ltr;
+}
+
+#adminModal .admin-modal-card {
+	background: #fff;
+	color: #111;
+	border-radius: 8px;
+	width: min(90vw, 480px);
+	padding: 16px;
+	box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+}
+
+#adminModal .admin-modal-title {
+	font-size: 18px;
+	font-weight: 700;
+	margin-bottom: 8px;
+}
+
+#adminModal .admin-modal-body {
+	font-size: 14px;
+	margin-bottom: 12px;
+	white-space: pre-wrap;
+	word-wrap: break-word;
+}
+
+#adminModal .admin-modal-body-info {
+	max-height: 200px;
+	overflow-y: auto;
+	background: #f3f4f6;
+	padding: 8px;
+	border-radius: 4px;
+	font-family: monospace;
+	font-size: 12px;
+}
+
+#adminModal.admin-preview-overlay {
+	padding: 0;
+	align-items: stretch;
+	justify-content: stretch;
+}
+
+#adminModal .admin-preview-card {
+	display: flex;
+	flex-direction: column;
+	width: 100vw;
+	height: 100vh;
+	max-width: none;
+	background: #fff;
+	border-radius: 0;
+	box-shadow: none;
+	padding: 0;
+}
+
+#adminModal .admin-preview-header {
+	padding: 10px 14px 6px;
+	border-bottom: 1px solid #e5e7eb;
+	background: #f9fafb;
+}
+
+#adminModal .admin-preview-title {
+	font-weight: 600;
+	font-size: 14px;
+	color: #111827;
+}
+
+#adminModal .admin-preview-path {
+	font-family: monospace;
+	color: #2563eb;
+}
+
+#adminModal .admin-preview-hint {
+	font-size: 12px;
+	color: #6b7280;
+	margin-top: 2px;
+}
+
+#adminModal .admin-preview-frame {
+	flex: 1 1 auto;
+	width: 100%;
+	border: none;
+	background: #fff;
+}
+
+#adminModal .admin-preview-actions {
+	padding: 10px 14px;
+	border-top: 1px solid #e5e7eb;
+	background: #f9fafb;
+}
+
+#adminModal .admin-modal-pr-body {
+	background: #f3f4f6;
+	padding: 10px;
+	border-radius: 4px;
+	font-family: inherit;
+	font-size: 14px;
+	max-height: none;
+	overflow: visible;
+}
+
+#adminModal .admin-modal-pr-label {
+	margin-bottom: 6px;
+	color: #111827;
+}
+
+#adminModal .admin-modal-pr-link {
+	display: block;
+	color: #2563eb;
+	text-decoration: underline;
+	word-break: break-all;
+	font-family: monospace;
+	font-size: 12px;
+}
+
+#adminModal .admin-modal-input {
+	width: 100%;
+	padding: 8px;
+	font-size: 14px;
+	border: 1px solid #d1d5db;
+	border-radius: 4px;
+	box-sizing: border-box;
+	margin-bottom: 12px;
+}
+
+#adminModal .admin-modal-actions {
+	display: flex;
+	justify-content: flex-end;
+	gap: 8px;
+}
+
+#adminModal .admin-modal-actions button {
+	background: #1f2937;
+	color: #fff;
+	border: none;
+	border-radius: 4px;
+	padding: 8px 16px;
+	font-size: 14px;
+	font-weight: 600;
+	cursor: pointer;
+	min-width: 80px;
+}
+
+#adminModal .admin-modal-cancel {
+	background: #6b7280 !important;
+}
+
+#adminModal .admin-modal-actions button:active {
+	opacity: 0.8;
+}

--- a/assets/html/js/admin.js
+++ b/assets/html/js/admin.js
@@ -1,0 +1,958 @@
+// ============================================================
+// Admin editor for Torah/Tanah HTML pages.
+//
+// Activation:
+//   - On every page load, admin.js asks Flutter (via the
+//     AdminBridge JS handler, action `isAdminActive`) whether the
+//     admin session is already unlocked. If yes, it activates
+//     silently with NO prompt - so navigating between pasukim
+//     never re-prompts for the passphrase.
+//   - Five quick taps (within 1.5s, in the top 100px banner)
+//     trigger `requestAdminUnlock`, which prompts for the passphrase
+//     once. After that, the Flutter bridge holds the unlocked flag
+//     in memory until the user taps the toolbar X or the app dies.
+//   - We avoid long-press because the Android WebView intercepts
+//     long-press for native text selection.
+//
+// Editing model:
+//   - Children of `.newPassuk` are made contentEditable so the
+//     user can fix letters in place.
+//   - A floating toolbar with a "Select" toggle lets the user
+//     pick a perush block (rashi / gurarie / onkelos / sforno /
+//     ...) and cut, copy, paste, or move it up/down.
+//   - On desktop, holding Shift while clicking a block also
+//     selects it (no need to flip the toggle).
+//
+// Submit:
+//   - Calls window.flutter_inappwebview.callHandler('AdminBridge',
+//     { action: 'submitEdit', filePath, newContent, message })
+//   - Flutter handles the GitHub PR creation.
+// ============================================================
+
+(function () {
+	"use strict";
+
+	var EDITABLE_BLOCK_CLASSES = [
+		"passukIvrit", "passukFr", "passukEn",
+		"onkelos", "yonatan", "rashi", "siftey",
+		"ibnEzra", "ramban", "sforno", "baalHaturim",
+		"orHaHaim", "kliYakar", "daatZkenim", "haemekDavar",
+		"abarbanel", "rashbam", "gurarie", "malbim",
+		"mezudatDavid", "mezudatZion", "ralbag", "radak",
+	];
+
+	var TAP_BURST_COUNT = 5;        // taps required
+	var TAP_BURST_WINDOW_MS = 1500; // within this window
+	var TAP_HOT_ZONE_HEIGHT = 100;  // taps must land in the top N px
+
+	// Per-tab state.
+	var state = {
+		active: false,
+		selectMode: false,    // when true, tap selects a block instead of typing
+		pasteMode: false,     // when true, tap pastes clipboard after the tapped block
+		selectedEl: null,
+		clipboardHtml: null,
+		undoStack: [],
+		redoStack: [],
+		toolbarEl: null,
+		pendingEdits: {}, // filePath -> outerHTML; used if you want multi-file batch later
+	};
+
+	function log() {
+		try {
+			var args = ["[admin]"];
+			for (var i = 0; i < arguments.length; i++) args.push(arguments[i]);
+			console.log.apply(console, args);
+		} catch (e) {}
+	}
+
+	function hasFlutterBridge() {
+		return typeof window.flutter_inappwebview !== "undefined" &&
+			typeof window.flutter_inappwebview.callHandler === "function";
+	}
+
+	function callBridge(payload) {
+		if (!hasFlutterBridge()) {
+			log("callBridge: no bridge", payload);
+			showInfoModal("Admin bridge", "Admin bridge not available (run inside the app).");
+			return Promise.reject(new Error("no bridge"));
+		}
+		log("callBridge ->", payload);
+		return window.flutter_inappwebview.callHandler("AdminBridge", payload);
+	}
+
+	// Returns "Bereshit/1.html" style path from the current URL.
+	function getCurrentFilePath() {
+		var path = window.location.pathname || "";
+		var markers = ["/html_content/", "/assets/html/"];
+		for (var i = 0; i < markers.length; i++) {
+			var idx = path.indexOf(markers[i]);
+			if (idx >= 0) {
+				return decodeURIComponent(path.substring(idx + markers[i].length));
+			}
+		}
+		// Fallback: just the file name.
+		var parts = path.split("/");
+		return decodeURIComponent(parts.slice(-2).join("/"));
+	}
+
+	// ============================================================
+	// Tap-burst hot zone to open the admin gateway.
+	//
+	// 5 quick taps in the top 100px of the screen within 1.5s.
+	// The hot zone is invisible to non-admins. We use touchend
+	// (not click) because the click event can be cancelled by the
+	// WebView's text-selection gesture on Android.
+	// ============================================================
+
+	function installTapBurstHandler() {
+		var taps = [];
+
+		function record(y) {
+			if (y > TAP_HOT_ZONE_HEIGHT) {
+				taps.length = 0;
+				return;
+			}
+			var now = Date.now();
+			taps.push(now);
+			while (taps.length > 0 && now - taps[0] > TAP_BURST_WINDOW_MS) {
+				taps.shift();
+			}
+			if (taps.length >= TAP_BURST_COUNT) {
+				taps.length = 0;
+				triggerUnlock();
+			}
+		}
+
+		document.addEventListener("touchend", function (e) {
+			var t = (e.changedTouches && e.changedTouches[0]) || null;
+			if (!t) return;
+			record(t.clientY || 0);
+		}, { passive: true, capture: true });
+
+		document.addEventListener("mouseup", function (e) {
+			record(e.clientY || 0);
+		}, true);
+	}
+
+	function triggerUnlock() {
+		if (state.active) {
+			log("triggerUnlock: already active, ignoring tap-burst");
+			return;
+		}
+		if (!hasFlutterBridge()) {
+			showInfoModal("Admin bridge", "Admin bridge not available (need to run inside the app).");
+			return;
+		}
+		log("triggerUnlock: requesting admin unlock");
+		callBridge({ action: "requestAdminUnlock" })
+			.then(function (granted) {
+				log("triggerUnlock result =", granted);
+				if (granted === true || granted === "true") {
+					activate();
+				}
+			})
+			.catch(function (err) {
+				log("triggerUnlock error", err);
+			});
+	}
+
+	// ============================================================
+	// Editable surface
+	// ============================================================
+
+	function makeEditable() {
+		var passukim = document.getElementsByClassName("newPassuk");
+		for (var i = 0; i < passukim.length; i++) {
+			passukim[i].setAttribute("contenteditable", "true");
+			// Don't let inline buttons/links be activated while editing.
+			passukim[i].setAttribute("spellcheck", "false");
+		}
+	}
+
+	// Capture the current document body so we can roll back to it.
+	// We snapshot the body's innerHTML EXCLUDING any admin chrome
+	// (toolbar, badge, modals) - those get rebuilt fresh on restore.
+	function captureBody() {
+		var clone = document.body.cloneNode(true);
+		var dropIds = ["adminToolbar", "adminBadge", "adminModal"];
+		for (var i = 0; i < dropIds.length; i++) {
+			var n = clone.querySelector("#" + dropIds[i]);
+			if (n && n.parentNode) n.parentNode.removeChild(n);
+		}
+		// Also drop the runtime-only classes so a restore doesn't
+		// re-flag the body as "still in admin mode" by itself.
+		clone.classList.remove("admin-active");
+		clone.classList.remove("admin-select-mode");
+		clone.classList.remove("admin-paste-mode");
+		return clone.innerHTML;
+	}
+
+	function snapshot() {
+		try {
+			state.undoStack.push(captureBody());
+			if (state.undoStack.length > 50) state.undoStack.shift();
+			state.redoStack.length = 0;
+			log("snapshot taken, undo depth =", state.undoStack.length);
+		} catch (e) {
+			log("snapshot error:", e && e.message);
+		}
+	}
+
+	// Replace the body content with `html` and rewire admin mode. This
+	// preserves the toolbar / admin state without doing a destructive
+	// document.open() + document.write() (which kicks the WebView).
+	function restoreBody(html) {
+		// Stash and re-attach admin chrome so it doesn't disappear.
+		var toolbar = document.getElementById("adminToolbar");
+		var badge = document.getElementById("adminBadge");
+		var modal = document.getElementById("adminModal");
+		document.body.innerHTML = html;
+		if (toolbar) document.body.appendChild(toolbar);
+		if (badge) document.body.appendChild(badge);
+		if (modal) document.body.appendChild(modal);
+		document.body.classList.add("admin-active");
+		if (state.selectMode) document.body.classList.add("admin-select-mode");
+		if (state.pasteMode) document.body.classList.add("admin-paste-mode");
+		// New nodes need contenteditable + listeners; old global click
+		// listener still works because it's on `document`.
+		makeEditable();
+		state.selectedEl = null;
+		updateToolbarSelectionLabel();
+	}
+
+	function undo() {
+		log("undo tapped, undo depth =", state.undoStack.length);
+		if (state.undoStack.length === 0) {
+			flashToolbar("Nothing to undo");
+			return;
+		}
+		state.redoStack.push(captureBody());
+		var prev = state.undoStack.pop();
+		restoreBody(prev);
+		flashToolbar("Undone");
+	}
+
+	function redo() {
+		log("redo tapped, redo depth =", state.redoStack.length);
+		if (state.redoStack.length === 0) {
+			flashToolbar("Nothing to redo");
+			return;
+		}
+		state.undoStack.push(captureBody());
+		var next = state.redoStack.pop();
+		restoreBody(next);
+		flashToolbar("Redone");
+	}
+
+	// ============================================================
+	// Selection
+	// ============================================================
+
+	function clearSelectionStyle() {
+		if (state.selectedEl) {
+			state.selectedEl.classList.remove("admin-selected");
+			state.selectedEl = null;
+		}
+	}
+
+	function findEditableAncestor(el) {
+		while (el && el !== document.body) {
+			if (el.classList) {
+				for (var i = 0; i < EDITABLE_BLOCK_CLASSES.length; i++) {
+					if (el.classList.contains(EDITABLE_BLOCK_CLASSES[i])) {
+						return el;
+					}
+				}
+			}
+			el = el.parentElement;
+		}
+		return null;
+	}
+
+	function onDocumentClick(e) {
+		if (!state.active) return;
+		if (state.toolbarEl && state.toolbarEl.contains(e.target)) return;
+		if (e.target.closest && e.target.closest("#adminModal")) return;
+
+		if (state.pasteMode) {
+			e.preventDefault();
+			e.stopPropagation();
+			var inserted = pasteAtCaret(e.clientX, e.clientY);
+			if (inserted === "no-clipboard") {
+				showInfoModal("Empty clipboard", "Cut or copy a block first.");
+			} else if (inserted === "no-target") {
+				showInfoModal("Bad target", "Tap inside a perush block (e.g. inside the Rashi text) to choose where to paste.");
+				return; // keep paste mode on so user can try again
+			} else {
+				flashToolbar("Pasted");
+			}
+			setPasteMode(false);
+			return;
+		}
+
+		if (!state.selectMode && !e.shiftKey) return;
+		var block = findEditableAncestor(e.target);
+		log("click in SELECT mode, ancestor =", describeBlock(block));
+		if (!block) return;
+		e.preventDefault();
+		e.stopPropagation();
+		clearSelectionStyle();
+		state.selectedEl = block;
+		block.classList.add("admin-selected");
+		updateToolbarSelectionLabel();
+	}
+
+	function setSelectMode(on) {
+		state.selectMode = !!on;
+		if (state.selectMode) setPasteMode(false);
+		if (document.body) {
+			document.body.classList.toggle("admin-select-mode", state.selectMode);
+		}
+		var btn = document.getElementById("adminSelectToggle");
+		if (btn) {
+			btn.textContent = state.selectMode ? "Select: ON" : "Select: OFF";
+			btn.classList.toggle("admin-toggle-on", state.selectMode);
+		}
+		updateToolbarSelectionLabel();
+	}
+
+	function setPasteMode(on) {
+		state.pasteMode = !!on;
+		if (document.body) {
+			document.body.classList.toggle("admin-paste-mode", state.pasteMode);
+		}
+		updateToolbarSelectionLabel();
+	}
+
+	function updateToolbarSelectionLabel() {
+		var label = document.getElementById("adminSelectionLabel");
+		if (!label) return;
+		if (state.pasteMode) {
+			label.textContent = "Paste: tap exact spot";
+		} else if (state.selectedEl) {
+			var classes = state.selectedEl.className || "";
+			label.textContent = "Selected: " + classes.split(" ")[0];
+		} else if (state.selectMode) {
+			label.textContent = "Select mode: tap a block";
+		} else {
+			label.textContent = "Tap Select, then a block";
+		}
+	}
+
+	// ============================================================
+	// Block operations
+	// ============================================================
+
+	function describeBlock(el) {
+		if (!el) return "(none)";
+		var cls = (el.className || "").split(" ")[0];
+		var id = el.id ? "#" + el.id : "";
+		return el.tagName + "." + cls + id;
+	}
+
+	function ensureSelected() {
+		if (!state.selectedEl) {
+			log("ensureSelected: no block selected");
+			showInfoModal("No selection", "Tap 'Select' on the toolbar, then tap a block to pick it.");
+			return false;
+		}
+		return true;
+	}
+
+	// For perush spans that are paired with a footnote marker
+	// (`<span onclick='hideShowById("ID")'>[N]</span>` + 
+	//  `<span id='ID' class='gurarie' style='display:none'>...</span>`),
+	// find the marker so cut/copy/paste move BOTH together.
+	// Returns null if there's no matching marker.
+	function findFootnoteMarkerFor(perushSpan) {
+		if (!perushSpan || !perushSpan.id) return null;
+		var id = perushSpan.id;
+		// Walk siblings backward looking for an onclick that mentions our id.
+		var sib = perushSpan.previousSibling;
+		var hops = 0;
+		while (sib && hops < 6) {
+			if (sib.nodeType === 1) {
+				var oc = sib.getAttribute && sib.getAttribute("onclick");
+				if (oc && oc.indexOf('"' + id + '"') >= 0) return sib;
+				if (oc && oc.indexOf("'" + id + "'") >= 0) return sib;
+				hops++;
+			}
+			sib = sib.previousSibling;
+		}
+		// Fallback: scan the whole document for the matching onclick.
+		var all = document.querySelectorAll("[onclick]");
+		for (var i = 0; i < all.length; i++) {
+			if (all[i] === perushSpan) continue;
+			var s = all[i].getAttribute("onclick") || "";
+			if (s.indexOf('"' + id + '"') >= 0 || s.indexOf("'" + id + "'") >= 0) {
+				return all[i];
+			}
+		}
+		return null;
+	}
+
+	// Build the "cut group" for the current selection: an array of
+	// nodes that belong together. For a marker-paired span (e.g.
+	// gurarie / siftey hidden block) we cut the marker + the span.
+	// Otherwise just the selection itself.
+	function selectionGroup() {
+		var sel = state.selectedEl;
+		if (!sel) return [];
+		// Only auto-pair if the selection is a hidden span with an id.
+		var isPaired = sel.tagName === "SPAN" && sel.id &&
+			(sel.classList.contains("gurarie") ||
+				sel.classList.contains("siftey"));
+		if (!isPaired) return [sel];
+		var marker = findFootnoteMarkerFor(sel);
+		if (!marker) return [sel];
+		// Order: marker first, then perush span (visual reading order).
+		// We sort by document position to be safe.
+		if (marker.compareDocumentPosition(sel) & Node.DOCUMENT_POSITION_FOLLOWING) {
+			return [marker, sel];
+		}
+		return [sel, marker];
+	}
+
+	function groupOuterHtml(nodes) {
+		var html = "";
+		for (var i = 0; i < nodes.length; i++) {
+			html += nodes[i].outerHTML;
+		}
+		return html;
+	}
+
+	function cutBlock() {
+		log("cutBlock tapped, selected =", describeBlock(state.selectedEl));
+		if (!ensureSelected()) return;
+		snapshot();
+		var group = selectionGroup();
+		log("cutBlock group size =", group.length);
+		state.clipboardHtml = groupOuterHtml(group);
+		for (var i = 0; i < group.length; i++) {
+			if (group[i].parentNode) group[i].parentNode.removeChild(group[i]);
+		}
+		state.selectedEl = null;
+		setPasteMode(true);
+		flashToolbar(group.length > 1
+			? "Cut " + group.length + " linked nodes. Tap exact spot to paste."
+			: "Cut. Tap exact spot inside a block to paste there.");
+		log("cutBlock done, paste mode = ON, clipboard length =",
+			state.clipboardHtml.length);
+	}
+
+	function copyBlock() {
+		log("copyBlock tapped, selected =", describeBlock(state.selectedEl));
+		if (!ensureSelected()) return;
+		var group = selectionGroup();
+		log("copyBlock group size =", group.length);
+		state.clipboardHtml = groupOuterHtml(group);
+		flashToolbar(group.length > 1
+			? "Copied " + group.length + " linked nodes. Tap exact spot to paste."
+			: "Copied. Tap exact spot inside a block to paste there.");
+		setPasteMode(true);
+		log("copyBlock done, paste mode = ON");
+	}
+
+	// Returns a Range located exactly at the (x,y) tap coordinates.
+	// Tries the modern API first, then the legacy one. Returns null if
+	// the platform supports neither.
+	function caretRangeAt(x, y) {
+		if (typeof document.caretRangeFromPoint === "function") {
+			return document.caretRangeFromPoint(x, y);
+		}
+		if (typeof document.caretPositionFromPoint === "function") {
+			var p = document.caretPositionFromPoint(x, y);
+			if (!p) return null;
+			var r = document.createRange();
+			r.setStart(p.offsetNode, p.offset);
+			r.collapse(true);
+			return r;
+		}
+		return null;
+	}
+
+	// Paste the clipboard content right at the tap (x,y). Returns:
+	//   "ok"           -> inserted at caret
+	//   "no-clipboard" -> nothing in clipboard
+	//   "no-target"    -> tap landed outside any editable block
+	function pasteAtCaret(x, y) {
+		log("pasteAtCaret at", x, y,
+			"clipboard length =", state.clipboardHtml ? state.clipboardHtml.length : 0);
+		if (!state.clipboardHtml) return "no-clipboard";
+		var range = caretRangeAt(x, y);
+		// Validate that the caret is actually inside an editable block
+		// (otherwise we'd paste into the toolbar / nav / etc.).
+		var anchorEl = range && range.startContainer;
+		if (anchorEl && anchorEl.nodeType === 3) anchorEl = anchorEl.parentNode;
+		var blockAncestor = anchorEl && findEditableAncestor(anchorEl);
+		if (!range || !blockAncestor) {
+			log("pasteAtCaret: no usable caret position");
+			return "no-target";
+		}
+		snapshot();
+		var tmp = document.createElement("div");
+		tmp.innerHTML = state.clipboardHtml;
+		var nodes = [];
+		while (tmp.firstChild) nodes.push(tmp.removeChild(tmp.firstChild));
+		// Insert all clipboard nodes at the caret in order.
+		var inserted = 0;
+		for (var i = nodes.length - 1; i >= 0; i--) {
+			range.insertNode(nodes[i]);
+			inserted++;
+		}
+		log("pasteAtCaret inserted", inserted, "node(s) into",
+			describeBlock(blockAncestor));
+		return "ok";
+	}
+
+	// ============================================================
+	// Submit
+	// ============================================================
+
+	function discard() {
+		showConfirmModal("Discard edits", "Discard ALL local edits and reload from disk?", function (ok) {
+			if (ok) window.location.reload();
+		});
+	}
+
+	// Build the HTML we'll commit to GitHub. CRITICAL: this must look
+	// like what a normal (non-admin) user would see - no toolbar, no
+	// ADMIN badge, no `contenteditable`, no `body.admin-active`, etc.
+	// Otherwise the PR would ship admin chrome to every reader.
+	function serializeForCommit() {
+		// Clone the whole document so we don't mutate the live page.
+		var docClone = document.documentElement.cloneNode(true);
+
+		// 1. Strip admin-only DOM nodes that we appended at runtime.
+		var dropSelectors = [
+			"#adminToolbar", "#adminBadge", "#adminModal",
+		];
+		for (var i = 0; i < dropSelectors.length; i++) {
+			var matches = docClone.querySelectorAll(dropSelectors[i]);
+			for (var j = 0; j < matches.length; j++) {
+				if (matches[j].parentNode) {
+					matches[j].parentNode.removeChild(matches[j]);
+				}
+			}
+		}
+
+		// 2. Strip body-level admin classes.
+		var bodyClone = docClone.querySelector("body");
+		if (bodyClone) {
+			var stripClasses = [
+				"admin-active", "admin-select-mode",
+				"admin-paste-mode", "admin-show-all",
+			];
+			for (var k = 0; k < stripClasses.length; k++) {
+				bodyClone.classList.remove(stripClasses[k]);
+			}
+			if (bodyClone.classList.length === 0) {
+				bodyClone.removeAttribute("class");
+			}
+		}
+
+		// 3. Strip per-element admin attributes / classes added by the
+		// editor (contenteditable, spellcheck="false", admin-selected
+		// outline). We only added these to elements with class
+		// "newPassuk", but be permissive in case anything else got it.
+		var editable = docClone.querySelectorAll("[contenteditable]");
+		for (var n = 0; n < editable.length; n++) {
+			editable[n].removeAttribute("contenteditable");
+		}
+		var spellch = docClone.querySelectorAll("[spellcheck='false']");
+		for (var s = 0; s < spellch.length; s++) {
+			// Only strip if WE set it (newPassuk regions).
+			if (spellch[s].classList.contains("newPassuk")) {
+				spellch[s].removeAttribute("spellcheck");
+			}
+		}
+		var sel = docClone.querySelectorAll(".admin-selected");
+		for (var t = 0; t < sel.length; t++) {
+			sel[t].classList.remove("admin-selected");
+			if (sel[t].classList.length === 0) {
+				sel[t].removeAttribute("class");
+			}
+		}
+
+		// Reconstruct full HTML document.
+		return "<!DOCTYPE html>\n" + docClone.outerHTML;
+	}
+
+	function submitEdit() {
+		log("submitEdit tapped");
+		var defaultTitle = "Edit " + getCurrentFilePath();
+		showInputModal("Submit PR", "Short description of this change (PR title):", defaultTitle, function (msg) {
+			log("submitEdit title =", msg);
+			if (!msg) return;
+			clearSelectionStyle();
+			var html = serializeForCommit();
+			log("submitEdit serialized HTML length =", html.length);
+			var filePath = getCurrentFilePath();
+			showPreviewOverlay(html, filePath, function (confirmed) {
+				if (!confirmed) {
+					log("submitEdit preview cancelled");
+					return;
+				}
+				doSubmitAfterPreview(html, filePath, msg);
+			});
+		});
+	}
+
+	function doSubmitAfterPreview(html, filePath, msg) {
+		flashToolbar("Submitting...");
+		callBridge({
+			action: "submitEdit",
+			filePath: filePath,
+			newContent: html,
+			message: msg,
+		}).then(function (result) {
+			if (result && result.url) {
+				// Apply locally so the user sees the edit immediately,
+				// without waiting for the next background sync.
+				callBridge({
+					action: "writeLocalFile",
+					filePath: filePath,
+					newContent: html,
+				}).catch(function (e) {
+					log("writeLocalFile failed:", e);
+				});
+				showPrSuccessModal("PR opened", result.url, result.number);
+			} else if (result && result.error) {
+				showInfoModal("Failed", result.error);
+			} else {
+				showInfoModal("Submitted", "(no URL returned)");
+			}
+		}).catch(function (err) {
+			showInfoModal("Submit failed", (err && err.message) ? err.message : String(err));
+		});
+	}
+
+	// Renders a fullscreen iframe with `srcdoc=html` so the user can
+	// see exactly how the page will look after the edit is committed.
+	// `onResult(true)` to confirm and submit, `onResult(false)` to cancel.
+	function showPreviewOverlay(html, filePath, onResult) {
+		dismissAllAdminModals();
+		var overlay = document.createElement("div");
+		overlay.id = "adminModal";
+		overlay.className = "admin-preview-overlay";
+		overlay.innerHTML = ""
+			+ "<div class='admin-preview-card'>"
+			+ "  <div class='admin-preview-header'>"
+			+ "    <div class='admin-preview-title'>Preview: <span class='admin-preview-path'></span></div>"
+			+ "    <div class='admin-preview-hint'>Scroll inside the preview to verify formatting before submitting.</div>"
+			+ "  </div>"
+			+ "  <iframe class='admin-preview-frame' sandbox='allow-same-origin'></iframe>"
+			+ "  <div class='admin-modal-actions admin-preview-actions'>"
+			+ "    <button class='admin-modal-cancel'>Back to edit</button>"
+			+ "    <button class='admin-modal-ok'>Looks good \u2014 submit</button>"
+			+ "  </div>"
+			+ "</div>";
+		overlay.querySelector(".admin-preview-path").textContent = filePath;
+		var frame = overlay.querySelector(".admin-preview-frame");
+		// srcdoc renders the HTML with the same UA/CSS engine the real
+		// page will use; this is the closest thing to the post-merge view.
+		frame.setAttribute("srcdoc", html);
+		document.body.appendChild(overlay);
+		var done = false;
+		function finish(result) {
+			if (done) return;
+			done = true;
+			if (overlay.parentNode) overlay.parentNode.removeChild(overlay);
+			onResult(result);
+		}
+		overlay.querySelector(".admin-modal-cancel").addEventListener("click", function () { finish(false); });
+		overlay.querySelector(".admin-modal-ok").addEventListener("click", function () { finish(true); });
+	}
+
+	// In-page modals to avoid WebView prompt()/alert() compatibility issues.
+	function dismissAllAdminModals() {
+		var existing = document.querySelectorAll("#adminModal");
+		for (var i = 0; i < existing.length; i++) {
+			if (existing[i].parentNode) existing[i].parentNode.removeChild(existing[i]);
+		}
+	}
+
+	function buildOverlay() {
+		dismissAllAdminModals();
+		var overlay = document.createElement("div");
+		overlay.id = "adminModal";
+		return overlay;
+	}
+
+	function attachDismiss(overlay, onDismiss) {
+		var dismissed = false;
+		function teardown() {
+			if (overlay.parentNode) overlay.parentNode.removeChild(overlay);
+			document.removeEventListener("keydown", onKey, true);
+		}
+		function dismissByUser() {
+			if (dismissed) return;
+			dismissed = true;
+			teardown();
+			if (onDismiss) onDismiss();
+		}
+		function onKey(e) {
+			if (e.key === "Escape" || e.keyCode === 27) {
+				e.preventDefault();
+				dismissByUser();
+			}
+		}
+		document.addEventListener("keydown", onKey, true);
+		// Tap on the dark backdrop (outside the white card) closes the modal.
+		overlay.addEventListener("click", function (e) {
+			if (e.target === overlay) dismissByUser();
+		});
+		// __close is for the explicit OK/Cancel buttons - it does NOT call onDismiss.
+		overlay.__close = function () {
+			dismissed = true;
+			teardown();
+		};
+	}
+
+	function showInputModal(title, body, defaultValue, onSubmit) {
+		var overlay = buildOverlay();
+		overlay.innerHTML = ""
+			+ "<div class='admin-modal-card'>"
+			+ "  <div class='admin-modal-title'></div>"
+			+ "  <div class='admin-modal-body'></div>"
+			+ "  <input class='admin-modal-input' type='text' />"
+			+ "  <div class='admin-modal-actions'>"
+			+ "    <button class='admin-modal-cancel'>Cancel</button>"
+			+ "    <button class='admin-modal-ok'>OK</button>"
+			+ "  </div>"
+			+ "</div>";
+		overlay.querySelector(".admin-modal-title").textContent = title;
+		overlay.querySelector(".admin-modal-body").textContent = body;
+		var input = overlay.querySelector(".admin-modal-input");
+		input.value = defaultValue || "";
+		document.body.appendChild(overlay);
+		attachDismiss(overlay, function () { onSubmit(null); });
+		var submitted = false;
+		input.focus();
+		input.select();
+		overlay.querySelector(".admin-modal-cancel").addEventListener("click", function () {
+			submitted = true;
+			overlay.__close();
+			onSubmit(null);
+		});
+		overlay.querySelector(".admin-modal-ok").addEventListener("click", function () {
+			submitted = true;
+			var v = input.value;
+			overlay.__close();
+			onSubmit(v);
+		});
+	}
+
+	function showInfoModal(title, body) {
+		var overlay = buildOverlay();
+		overlay.innerHTML = ""
+			+ "<div class='admin-modal-card'>"
+			+ "  <div class='admin-modal-title'></div>"
+			+ "  <div class='admin-modal-body admin-modal-body-info'></div>"
+			+ "  <div class='admin-modal-actions'>"
+			+ "    <button class='admin-modal-ok'>OK</button>"
+			+ "  </div>"
+			+ "</div>";
+		overlay.querySelector(".admin-modal-title").textContent = title;
+		overlay.querySelector(".admin-modal-body").textContent = body;
+		document.body.appendChild(overlay);
+		attachDismiss(overlay);
+		overlay.querySelector(".admin-modal-ok").addEventListener("click", function () {
+			overlay.__close();
+		});
+	}
+
+	// Renders the PR-opened success modal with a clickable link that asks
+	// Flutter to open the URL in the system browser (the WebView itself
+	// can't navigate to github.com without losing the admin session).
+	function showPrSuccessModal(title, url, number) {
+		var overlay = buildOverlay();
+		var label = number ? ("Pull request #" + number + " opened.") : "Pull request opened.";
+		overlay.innerHTML = ""
+			+ "<div class='admin-modal-card'>"
+			+ "  <div class='admin-modal-title'></div>"
+			+ "  <div class='admin-modal-body admin-modal-pr-body'>"
+			+ "    <div class='admin-modal-pr-label'></div>"
+			+ "    <a class='admin-modal-pr-link' href='#' rel='noopener'></a>"
+			+ "  </div>"
+			+ "  <div class='admin-modal-actions'>"
+			+ "    <button class='admin-modal-cancel'>Close</button>"
+			+ "    <button class='admin-modal-ok'>Open in browser</button>"
+			+ "  </div>"
+			+ "</div>";
+		overlay.querySelector(".admin-modal-title").textContent = title;
+		overlay.querySelector(".admin-modal-pr-label").textContent = label;
+		var link = overlay.querySelector(".admin-modal-pr-link");
+		link.textContent = url;
+		link.setAttribute("href", url);
+		document.body.appendChild(overlay);
+		attachDismiss(overlay);
+		function openExternal(e) {
+			if (e) { e.preventDefault(); e.stopPropagation(); }
+			callBridge({ action: "openUrl", url: url }).catch(function () {});
+		}
+		link.addEventListener("click", openExternal);
+		overlay.querySelector(".admin-modal-ok").addEventListener("click", function () {
+			openExternal();
+			overlay.__close();
+		});
+		overlay.querySelector(".admin-modal-cancel").addEventListener("click", function () {
+			overlay.__close();
+		});
+	}
+
+	function showConfirmModal(title, body, onResult) {
+		var overlay = buildOverlay();
+		overlay.innerHTML = ""
+			+ "<div class='admin-modal-card'>"
+			+ "  <div class='admin-modal-title'></div>"
+			+ "  <div class='admin-modal-body admin-modal-body-info'></div>"
+			+ "  <div class='admin-modal-actions'>"
+			+ "    <button class='admin-modal-cancel'>Cancel</button>"
+			+ "    <button class='admin-modal-ok'>OK</button>"
+			+ "  </div>"
+			+ "</div>";
+		overlay.querySelector(".admin-modal-title").textContent = title;
+		overlay.querySelector(".admin-modal-body").textContent = body;
+		document.body.appendChild(overlay);
+		attachDismiss(overlay, function () { onResult(false); });
+		overlay.querySelector(".admin-modal-cancel").addEventListener("click", function () {
+			overlay.__close();
+			onResult(false);
+		});
+		overlay.querySelector(".admin-modal-ok").addEventListener("click", function () {
+			overlay.__close();
+			onResult(true);
+		});
+	}
+
+	function openSettings() {
+		callBridge({ action: "openSettings" }).catch(function () {});
+	}
+
+	function disableAdminMode() {
+		log("disableAdminMode tapped");
+		showConfirmModal("Exit admin mode", "Exit admin mode?", function (ok) {
+			log("disableAdminMode confirm =", ok);
+			if (!ok) return;
+			callBridge({ action: "clearAdminActive" })
+				.catch(function () {})
+				.then(function () { window.location.reload(); });
+		});
+	}
+
+	// ============================================================
+	// Toolbar
+	// ============================================================
+
+	function flashToolbar(text) {
+		var label = document.getElementById("adminFlash");
+		if (!label) return;
+		label.textContent = text;
+		label.style.opacity = "1";
+		setTimeout(function () { label.style.opacity = "0"; }, 1500);
+	}
+
+	function btn(text, handler, title) {
+		var b = document.createElement("button");
+		b.type = "button";
+		b.textContent = text;
+		if (title) b.title = title;
+		b.addEventListener("click", function (e) {
+			e.preventDefault();
+			e.stopPropagation();
+			handler();
+		});
+		return b;
+	}
+
+	function buildToolbar() {
+		if (document.getElementById("adminToolbar")) return;
+		var bar = document.createElement("div");
+		bar.id = "adminToolbar";
+
+		var label = document.createElement("span");
+		label.id = "adminSelectionLabel";
+		label.textContent = "Tap Select, then a block";
+		bar.appendChild(label);
+
+		var selectBtn = btn("Select: OFF", function () { setSelectMode(!state.selectMode); }, "Toggle: tap a block to select it");
+		selectBtn.id = "adminSelectToggle";
+		bar.appendChild(selectBtn);
+		bar.appendChild(btn("Cut", cutBlock, "Cut selected block (then tap target to paste)"));
+		bar.appendChild(btn("Copy", copyBlock, "Copy selected block (then tap target to paste)"));
+		bar.appendChild(btn("Undo", undo));
+		bar.appendChild(btn("Redo", redo));
+		bar.appendChild(btn("Discard", discard, "Reload from disk"));
+		bar.appendChild(btn("Submit PR", submitEdit, "Submit as a GitHub Pull Request"));
+		bar.appendChild(btn("\u2699", openSettings, "Admin settings (token, sign out)"));
+		bar.appendChild(btn("\u2715", disableAdminMode, "Exit admin mode"));
+
+		var flash = document.createElement("span");
+		flash.id = "adminFlash";
+		bar.appendChild(flash);
+
+		document.body.appendChild(bar);
+		state.toolbarEl = bar;
+	}
+
+	function showAdminBadge() {
+		var badge = document.createElement("div");
+		badge.id = "adminBadge";
+		badge.textContent = "ADMIN";
+		document.body.appendChild(badge);
+	}
+
+	// ============================================================
+	// Boot
+	// ============================================================
+
+	function activate() {
+		if (state.active) return;
+		log("activate: turning admin mode ON");
+		state.active = true;
+		makeEditable();
+		buildToolbar();
+		showAdminBadge();
+		if (document.body) {
+			document.body.classList.add("admin-active");
+		}
+		document.addEventListener("click", onDocumentClick, true);
+	}
+
+	function boot() {
+		log("boot: setting up tap-burst handler, page =", window.location.pathname);
+		installTapBurstHandler();
+		// Catch surprise navigations while admin is editing.
+		window.addEventListener("beforeunload", function (e) {
+			log("BEFOREUNLOAD active=" + state.active +
+				" pasteMode=" + state.pasteMode +
+				" hasClipboard=" + (!!state.clipboardHtml));
+		});
+		// Ask Flutter if the admin session was already unlocked. If yes,
+		// activate silently (no passphrase prompt on every page nav).
+		if (hasFlutterBridge()) {
+			callBridge({ action: "isAdminActive" })
+				.then(function (ok) {
+					log("boot isAdminActive =", ok);
+					if (ok === true || ok === "true") activate();
+				})
+				.catch(function (err) { log("boot isAdminActive error", err); });
+		}
+	}
+
+	if (document.readyState === "loading") {
+		document.addEventListener("DOMContentLoaded", boot);
+	} else {
+		boot();
+	}
+
+	// Expose a tiny API in case Flutter wants to push commands in.
+	window.__admin = {
+		activate: activate,
+		disable: disableAdminMode,
+		isActive: function () { return state.active; },
+		getCurrentFilePath: getCurrentFilePath,
+	};
+})();

--- a/assets/html/js/admin.js
+++ b/assets/html/js/admin.js
@@ -7,7 +7,7 @@
 //     admin session is already unlocked. If yes, it activates
 //     silently with NO prompt - so navigating between pasukim
 //     never re-prompts for the passphrase.
-//   - Five quick taps (within 1.5s, in the top 100px banner)
+//   - Ten quick taps (within 3s, in the top 100px banner)
 //     trigger `requestAdminUnlock`, which prompts for the passphrase
 //     once. After that, the Flutter bridge holds the unlocked flag
 //     in memory until the user taps the toolbar X or the app dies.
@@ -41,8 +41,8 @@
 		"mezudatDavid", "mezudatZion", "ralbag", "radak",
 	];
 
-	var TAP_BURST_COUNT = 5;        // taps required
-	var TAP_BURST_WINDOW_MS = 1500; // within this window
+	var TAP_BURST_COUNT = 10;       // taps required
+	var TAP_BURST_WINDOW_MS = 3000; // within this window (ms)
 	var TAP_HOT_ZONE_HEIGHT = 100;  // taps must land in the top N px
 
 	// Per-tab state.
@@ -99,7 +99,7 @@
 	// ============================================================
 	// Tap-burst hot zone to open the admin gateway.
 	//
-	// 5 quick taps in the top 100px of the screen within 1.5s.
+	// 10 quick taps in the top 100px of the screen within 3s.
 	// The hot zone is invisible to non-admins. We use touchend
 	// (not click) because the click event can be cancelled by the
 	// WebView's text-selection gesture on Android.

--- a/lib/admin/admin_bridge.dart
+++ b/lib/admin/admin_bridge.dart
@@ -1,0 +1,245 @@
+import 'dart:convert';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../update_service.dart';
+import 'admin_settings_screen.dart';
+import 'admin_storage.dart';
+import 'github_pr_service.dart';
+
+/// Wires up the JS-Flutter bridge and dispatches admin actions.
+///
+/// Actions sent by `assets/html/js/admin.js`:
+///
+///   { action: 'requestAdminUnlock' }
+///       -> prompts the user for the admin passphrase, returns true on success.
+///
+///   { action: 'submitEdit', filePath, newContent, message }
+///       -> creates a branch + commit + PR using the saved PAT.
+///
+///   { action: 'openSettings' }
+///       -> pushes AdminSettingsScreen.
+class AdminBridge {
+  final GlobalKey<NavigatorState> navigatorKey;
+  final AdminStorage _storage = AdminStorage();
+
+  /// Process-wide flag: once the user has unlocked admin mode in this
+  /// app session, every page navigation can re-enable admin mode without
+  /// asking for the passphrase again.
+  ///
+  /// Note: this is purely an in-memory hint to skip background WebView
+  /// reloads. The "is this device an admin device" decision is the
+  /// device-persistent flag stored by AdminStorage.setAdminEnabled().
+  static bool _sessionUnlocked = false;
+
+  static bool get isSessionUnlocked => _sessionUnlocked;
+
+  /// Called when the user un-enrolls the device from Settings, so the
+  /// in-memory hint matches the persistent flag.
+  static void clearSessionFlag() {
+    _sessionUnlocked = false;
+  }
+
+  AdminBridge({required this.navigatorKey});
+
+  void register(InAppWebViewController controller) {
+    controller.addJavaScriptHandler(
+      handlerName: 'AdminBridge',
+      callback: (args) async {
+        try {
+          final payload = (args.isNotEmpty && args[0] is Map)
+              ? Map<String, dynamic>.from(args[0] as Map)
+              : <String, dynamic>{};
+          final action = payload['action'] as String?;
+          switch (action) {
+            case 'isAdminActive':
+              // The page is active if the user is in the middle of an
+              // admin session in THIS process AND has an active toolbar.
+              // We don't auto-activate on page load just because the
+              // device is registered as an admin device - the user
+              // explicitly tapped X to hide the toolbar.
+              return _sessionUnlocked;
+            case 'clearAdminActive':
+              // Hide the toolbar for now, but keep the device-level
+              // admin enrolment so the next 5-tap doesn't reprompt.
+              _sessionUnlocked = false;
+              return true;
+            case 'requestAdminUnlock':
+              final ok = await _handleUnlock();
+              if (ok) _sessionUnlocked = true;
+              return ok;
+            case 'submitEdit':
+              return await _handleSubmit(payload);
+            case 'openSettings':
+              await _handleOpenSettings();
+              return true;
+            case 'openUrl':
+              final url = payload['url'] as String?;
+              return await _handleOpenUrl(url);
+            case 'writeLocalFile':
+              return await _handleWriteLocalFile(payload);
+            default:
+              return {'error': 'Unknown action: $action'};
+          }
+        } catch (e) {
+          return {'error': 'Bridge error: $e'};
+        }
+      },
+    );
+  }
+
+  // --------------- handlers ---------------
+
+  Future<bool> _handleUnlock() async {
+    final ctx = navigatorKey.currentContext;
+    if (ctx == null) return false;
+
+    // Once a device has been enrolled as an admin device (i.e. the user
+    // entered the correct passphrase here at least once), subsequent
+    // 5-tap bursts unlock silently with no prompt. The X button only
+    // hides the toolbar; it does NOT un-enroll the device.
+    final alreadyEnrolled = await _storage.isAdminEnabled();
+    if (alreadyEnrolled) return true;
+
+    final existingHash = await _storage.getPassphraseHash();
+    if (existingHash == null) {
+      // First time on this device: set a passphrase.
+      final newPass = await _promptPassphrase(
+        ctx,
+        title: 'Set admin passphrase',
+        body: 'No passphrase set yet. Choose one (min 6 characters).',
+      );
+      if (newPass == null || newPass.length < 6) return false;
+      await _storage.setPassphraseHash(_hash(newPass));
+      await _storage.setAdminEnabled(true);
+      return true;
+    }
+    // Passphrase exists but device not yet enrolled (e.g. admin was
+    // un-enrolled from settings, or the install was wiped). Verify.
+    final pass = await _promptPassphrase(
+      ctx,
+      title: 'Admin unlock',
+      body: 'Enter the admin passphrase to enable editing on this device.',
+    );
+    if (pass == null) return false;
+    if (_hash(pass) != existingHash) return false;
+    await _storage.setAdminEnabled(true);
+    return true;
+  }
+
+  Future<Map<String, dynamic>> _handleSubmit(
+      Map<String, dynamic> payload) async {
+    final filePath = payload['filePath'] as String?;
+    final newContent = payload['newContent'] as String?;
+    final message = (payload['message'] as String?)?.trim();
+    if (filePath == null || filePath.isEmpty) {
+      return {'error': 'Missing filePath.'};
+    }
+    if (newContent == null || newContent.isEmpty) {
+      return {'error': 'Missing newContent.'};
+    }
+    final title = (message == null || message.isEmpty)
+        ? 'Edit $filePath'
+        : message;
+
+    final token = await _storage.getToken();
+    if (token == null || token.isEmpty) {
+      return {
+        'error': 'No GitHub token saved. Open settings (gear icon) to add one.',
+      };
+    }
+    final svc = GithubPrService(token: token);
+    final result = await svc.submitEdit(
+      edits: [FileEdit(filePath, newContent)],
+      title: title,
+    );
+    if (result.success) {
+      return {'url': result.url, 'number': result.number};
+    }
+    return {'error': result.error ?? 'Unknown error'};
+  }
+
+  Future<Map<String, dynamic>> _handleWriteLocalFile(
+      Map<String, dynamic> payload) async {
+    final filePath = payload['filePath'] as String?;
+    final newContent = payload['newContent'] as String?;
+    if (filePath == null || filePath.isEmpty) {
+      return {'error': 'Missing filePath'};
+    }
+    if (newContent == null || newContent.isEmpty) {
+      return {'error': 'Missing newContent'};
+    }
+    // filePath comes from JS as a relative HTML path under assets/html,
+    // e.g. "Bereshit/1.html". UpdateService stores files in the same
+    // layout under <docs>/html_content/, so we can pass it through
+    // unchanged.
+    final ok =
+        await UpdateService.instance.writeLocalAssetFile(filePath, newContent);
+    return {'ok': ok};
+  }
+
+  Future<bool> _handleOpenUrl(String? url) async {
+    if (url == null || url.isEmpty) return false;
+    final uri = Uri.tryParse(url);
+    if (uri == null) return false;
+    return launchUrl(uri, mode: LaunchMode.externalApplication);
+  }
+
+  Future<void> _handleOpenSettings() async {
+    final navigator = navigatorKey.currentState;
+    if (navigator == null) return;
+    await navigator.push(
+      MaterialPageRoute(builder: (_) => const AdminSettingsScreen()),
+    );
+  }
+
+  // --------------- helpers ---------------
+
+  Future<String?> _promptPassphrase(
+    BuildContext context, {
+    required String title,
+    required String body,
+  }) async {
+    final controller = TextEditingController();
+    return showDialog<String>(
+      context: context,
+      barrierDismissible: false,
+      builder: (ctx) => AlertDialog(
+        title: Text(title),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(body),
+            const SizedBox(height: 8),
+            TextField(
+              controller: controller,
+              obscureText: true,
+              autofocus: true,
+              decoration: const InputDecoration(
+                border: OutlineInputBorder(),
+                labelText: 'Passphrase',
+              ),
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, null),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(ctx, controller.text),
+            child: const Text('OK'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _hash(String s) {
+    return sha256.convert(utf8.encode(s)).toString();
+  }
+}

--- a/lib/admin/admin_settings_screen.dart
+++ b/lib/admin/admin_settings_screen.dart
@@ -1,0 +1,235 @@
+import 'package:flutter/material.dart';
+
+import '../update_service.dart';
+import 'admin_bridge.dart';
+import 'admin_storage.dart';
+import 'github_pr_service.dart';
+
+class AdminSettingsScreen extends StatefulWidget {
+  const AdminSettingsScreen({super.key});
+
+  @override
+  State<AdminSettingsScreen> createState() => _AdminSettingsScreenState();
+}
+
+class _AdminSettingsScreenState extends State<AdminSettingsScreen> {
+  final _storage = AdminStorage();
+  final _tokenController = TextEditingController();
+  bool _loading = true;
+  String? _statusMessage;
+  bool _statusOk = false;
+  bool _hasToken = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final token = await _storage.getToken();
+    if (!mounted) return;
+    setState(() {
+      _hasToken = token != null && token.isNotEmpty;
+      _loading = false;
+    });
+  }
+
+  Future<void> _save() async {
+    final token = _tokenController.text.trim();
+    if (token.isEmpty) {
+      setState(() {
+        _statusOk = false;
+        _statusMessage = 'Token is empty.';
+      });
+      return;
+    }
+    await _storage.setToken(token);
+    _tokenController.clear();
+    if (!mounted) return;
+    setState(() {
+      _hasToken = true;
+      _statusOk = true;
+      _statusMessage = 'Token saved.';
+    });
+  }
+
+  Future<void> _test() async {
+    final token = await _storage.getToken();
+    if (token == null || token.isEmpty) {
+      setState(() {
+        _statusOk = false;
+        _statusMessage = 'No token saved yet.';
+      });
+      return;
+    }
+    setState(() {
+      _statusMessage = 'Testing...';
+      _statusOk = false;
+    });
+    final svc = GithubPrService(token: token);
+    final err = await svc.verifyToken();
+    if (!mounted) return;
+    setState(() {
+      if (err == null) {
+        _statusOk = true;
+        _statusMessage =
+            'OK. Token has access to ${UpdateConfig.owner}/${UpdateConfig.repo}.';
+      } else {
+        _statusOk = false;
+        _statusMessage = err;
+      }
+    });
+  }
+
+  Future<void> _signOut() async {
+    await _storage.clearToken();
+    if (!mounted) return;
+    setState(() {
+      _hasToken = false;
+      _statusOk = true;
+      _statusMessage = 'Token cleared.';
+    });
+  }
+
+  Future<void> _disableAdmin() async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Disable admin mode?'),
+        content: const Text(
+            'You will need the passphrase again to re-enable admin mode.'),
+        actions: [
+          TextButton(
+              onPressed: () => Navigator.pop(ctx, false),
+              child: const Text('Cancel')),
+          FilledButton(
+              onPressed: () => Navigator.pop(ctx, true),
+              child: const Text('Disable')),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+    await _storage.setAdminEnabled(false);
+    AdminBridge.clearSessionFlag();
+    if (!mounted) return;
+    Navigator.pop(context, 'admin-disabled');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Admin settings'),
+      ),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : ListView(
+              padding: const EdgeInsets.all(16),
+              children: [
+                Card(
+                  child: Padding(
+                    padding: const EdgeInsets.all(12),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          'GitHub repo',
+                          style: Theme.of(context).textTheme.titleMedium,
+                        ),
+                        const SizedBox(height: 4),
+                        SelectableText(
+                            '${UpdateConfig.owner}/${UpdateConfig.repo} (${UpdateConfig.branch})'),
+                      ],
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                Text(
+                  'Fine-grained personal access token',
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  _hasToken
+                      ? 'A token is currently saved. Paste a new one below to replace it.'
+                      : 'No token saved. Paste a token to enable PR submission.',
+                  style: Theme.of(context).textTheme.bodySmall,
+                ),
+                const SizedBox(height: 8),
+                TextField(
+                  controller: _tokenController,
+                  obscureText: true,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    labelText: 'github_pat_...',
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Row(
+                  children: [
+                    FilledButton.icon(
+                      onPressed: _save,
+                      icon: const Icon(Icons.save),
+                      label: const Text('Save'),
+                    ),
+                    const SizedBox(width: 8),
+                    OutlinedButton.icon(
+                      onPressed: _test,
+                      icon: const Icon(Icons.network_check),
+                      label: const Text('Test token'),
+                    ),
+                    const SizedBox(width: 8),
+                    if (_hasToken)
+                      TextButton.icon(
+                        onPressed: _signOut,
+                        icon: const Icon(Icons.logout),
+                        label: const Text('Sign out'),
+                      ),
+                  ],
+                ),
+                if (_statusMessage != null) ...[
+                  const SizedBox(height: 16),
+                  Container(
+                    padding: const EdgeInsets.all(10),
+                    decoration: BoxDecoration(
+                      color: _statusOk
+                          ? Colors.green.withValues(alpha: 0.15)
+                          : Colors.red.withValues(alpha: 0.15),
+                      borderRadius: BorderRadius.circular(6),
+                    ),
+                    child: Text(_statusMessage!),
+                  ),
+                ],
+                const SizedBox(height: 32),
+                const Divider(),
+                const SizedBox(height: 16),
+                OutlinedButton.icon(
+                  onPressed: _disableAdmin,
+                  icon: const Icon(Icons.lock),
+                  label: const Text('Exit admin mode'),
+                ),
+                const SizedBox(height: 24),
+                Text(
+                  'Required token scopes (fine-grained):',
+                  style: Theme.of(context).textTheme.titleSmall,
+                ),
+                const SizedBox(height: 4),
+                const Text(
+                  '  - Contents: Read and write\n'
+                  '  - Pull requests: Read and write\n'
+                  '  - Metadata: Read-only\n\n'
+                  'Restrict the token to ONLY this repo. Master must be branch-protected '
+                  'so the token cannot push to it directly.',
+                ),
+              ],
+            ),
+    );
+  }
+
+  @override
+  void dispose() {
+    _tokenController.dispose();
+    super.dispose();
+  }
+}

--- a/lib/admin/admin_storage.dart
+++ b/lib/admin/admin_storage.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+/// Thin wrapper around flutter_secure_storage for the admin feature.
+///
+/// Stores three secrets:
+///   - github_token: the fine-grained PAT
+///   - admin_passphrase_hash: SHA-256 of the unlock passphrase (set first time)
+///   - admin_enabled: '1' once the user has unlocked admin mode at least once
+class AdminStorage {
+  static const _kToken = 'admin_github_token';
+  static const _kPassHash = 'admin_passphrase_hash';
+  static const _kEnabled = 'admin_enabled';
+
+  final FlutterSecureStorage _storage = const FlutterSecureStorage();
+
+  Future<String?> getToken() => _storage.read(key: _kToken);
+  Future<void> setToken(String token) =>
+      _storage.write(key: _kToken, value: token);
+  Future<void> clearToken() => _storage.delete(key: _kToken);
+
+  Future<String?> getPassphraseHash() => _storage.read(key: _kPassHash);
+  Future<void> setPassphraseHash(String hash) =>
+      _storage.write(key: _kPassHash, value: hash);
+
+  Future<bool> isAdminEnabled() async =>
+      (await _storage.read(key: _kEnabled)) == '1';
+  Future<void> setAdminEnabled(bool enabled) async {
+    if (enabled) {
+      await _storage.write(key: _kEnabled, value: '1');
+    } else {
+      await _storage.delete(key: _kEnabled);
+    }
+  }
+}

--- a/lib/admin/github_pr_service.dart
+++ b/lib/admin/github_pr_service.dart
@@ -1,0 +1,227 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
+import '../update_service.dart';
+
+/// Result of a PR creation attempt.
+class PrResult {
+  final bool success;
+  final String? url;
+  final String? error;
+  final int? number;
+
+  PrResult.success(this.url, this.number)
+      : success = true,
+        error = null;
+  PrResult.failure(this.error)
+      : success = false,
+        url = null,
+        number = null;
+}
+
+/// One file edit: relative path under assets/html (e.g. 'Bereshit/1.html')
+/// + the new full file content.
+class FileEdit {
+  final String relativePath;
+  final String newContent;
+  FileEdit(this.relativePath, this.newContent);
+}
+
+/// Creates a branch, commits the edits, and opens a PR against `master`.
+/// `master` is expected to be branch-protected so this token cannot push
+/// to it directly even if it tried.
+class GithubPrService {
+  final String token;
+  final String owner;
+  final String repo;
+  final String baseBranch;
+
+  GithubPrService({
+    required this.token,
+    String? owner,
+    String? repo,
+    String? baseBranch,
+  })  : owner = owner ?? UpdateConfig.owner,
+        repo = repo ?? UpdateConfig.repo,
+        baseBranch = baseBranch ?? UpdateConfig.branch;
+
+  Map<String, String> get _headers => {
+        'Authorization': 'Bearer $token',
+        'Accept': 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+        'Content-Type': 'application/json',
+      };
+
+  String get _api => 'https://api.github.com/repos/$owner/$repo';
+
+  /// Verifies the token can read this repo. Useful for the "Test token" button.
+  Future<String?> verifyToken() async {
+    try {
+      final r = await http.get(Uri.parse(_api), headers: _headers);
+      if (r.statusCode == 200) return null;
+      return 'GitHub returned ${r.statusCode}: ${_shortBody(r)}';
+    } catch (e) {
+      return 'Network error: $e';
+    }
+  }
+
+  /// Implements the 7-step PR flow:
+  ///   1. GET base ref     -> baseSha
+  ///   2. POST a blob      -> blobSha (per file)
+  ///   3. POST a new tree  -> treeSha (with one entry per file)
+  ///   4. POST a commit    -> commitSha
+  ///   5. POST a new ref   -> refs/heads/admin-edit/<ts>-<slug>
+  ///   6. POST a pull req  -> PR url
+  Future<PrResult> submitEdit({
+    required List<FileEdit> edits,
+    required String title,
+    String? body,
+  }) async {
+    if (edits.isEmpty) {
+      return PrResult.failure('No edits to submit.');
+    }
+    try {
+      // Step 1: base ref
+      final refResp = await http.get(
+        Uri.parse('$_api/git/ref/heads/$baseBranch'),
+        headers: _headers,
+      );
+      if (refResp.statusCode != 200) {
+        return PrResult.failure(
+            'Could not fetch base ref ($baseBranch): ${_shortBody(refResp)}');
+      }
+      final baseSha = (json.decode(refResp.body)['object']
+          as Map<String, dynamic>)['sha'] as String;
+
+      // Need the base commit's tree for step 3.
+      final commitResp = await http.get(
+        Uri.parse('$_api/git/commits/$baseSha'),
+        headers: _headers,
+      );
+      if (commitResp.statusCode != 200) {
+        return PrResult.failure(
+            'Could not fetch base commit: ${_shortBody(commitResp)}');
+      }
+      final baseTreeSha = ((json.decode(commitResp.body) as Map)['tree']
+          as Map)['sha'] as String;
+
+      // Step 2: one blob per file
+      final treeEntries = <Map<String, dynamic>>[];
+      for (final edit in edits) {
+        final blobResp = await http.post(
+          Uri.parse('$_api/git/blobs'),
+          headers: _headers,
+          body: json.encode({
+            'content': base64.encode(utf8.encode(edit.newContent)),
+            'encoding': 'base64',
+          }),
+        );
+        if (blobResp.statusCode != 201) {
+          return PrResult.failure(
+              'Failed to create blob for ${edit.relativePath}: ${_shortBody(blobResp)}');
+        }
+        final blobSha = (json.decode(blobResp.body) as Map)['sha'] as String;
+        treeEntries.add({
+          'path': '${UpdateConfig.htmlPath}/${edit.relativePath}',
+          'mode': '100644',
+          'type': 'blob',
+          'sha': blobSha,
+        });
+      }
+
+      // Step 3: tree
+      final treeResp = await http.post(
+        Uri.parse('$_api/git/trees'),
+        headers: _headers,
+        body: json.encode({
+          'base_tree': baseTreeSha,
+          'tree': treeEntries,
+        }),
+      );
+      if (treeResp.statusCode != 201) {
+        return PrResult.failure('Failed to create tree: ${_shortBody(treeResp)}');
+      }
+      final treeSha = (json.decode(treeResp.body) as Map)['sha'] as String;
+
+      // Step 4: commit
+      final commitMessage = _commitMessage(title, edits);
+      final newCommitResp = await http.post(
+        Uri.parse('$_api/git/commits'),
+        headers: _headers,
+        body: json.encode({
+          'message': commitMessage,
+          'tree': treeSha,
+          'parents': [baseSha],
+        }),
+      );
+      if (newCommitResp.statusCode != 201) {
+        return PrResult.failure(
+            'Failed to create commit: ${_shortBody(newCommitResp)}');
+      }
+      final commitSha =
+          (json.decode(newCommitResp.body) as Map)['sha'] as String;
+
+      // Step 5: branch
+      final branchName = _branchName(title);
+      final refCreateResp = await http.post(
+        Uri.parse('$_api/git/refs'),
+        headers: _headers,
+        body: json.encode({
+          'ref': 'refs/heads/$branchName',
+          'sha': commitSha,
+        }),
+      );
+      if (refCreateResp.statusCode != 201) {
+        return PrResult.failure(
+            'Failed to create branch $branchName: ${_shortBody(refCreateResp)}');
+      }
+
+      // Step 6: pull request
+      final prResp = await http.post(
+        Uri.parse('$_api/pulls'),
+        headers: _headers,
+        body: json.encode({
+          'title': title,
+          'head': branchName,
+          'base': baseBranch,
+          'body': body ??
+              'Submitted from the in-app admin editor.\n\n'
+                  'Files changed:\n${edits.map((e) => '- ${e.relativePath}').join('\n')}',
+          'maintainer_can_modify': true,
+        }),
+      );
+      if (prResp.statusCode != 201) {
+        return PrResult.failure('Failed to open PR: ${_shortBody(prResp)}');
+      }
+      final pr = json.decode(prResp.body) as Map<String, dynamic>;
+      return PrResult.success(
+        pr['html_url'] as String?,
+        pr['number'] as int?,
+      );
+    } catch (e) {
+      return PrResult.failure('Unexpected error: $e');
+    }
+  }
+
+  String _commitMessage(String title, List<FileEdit> edits) {
+    final paths = edits.map((e) => e.relativePath).join(', ');
+    return '$title\n\nIn-app admin edit affecting: $paths';
+  }
+
+  String _branchName(String title) {
+    final ts = DateTime.now().millisecondsSinceEpoch;
+    final slug = title
+        .toLowerCase()
+        .replaceAll(RegExp(r'[^a-z0-9]+'), '-')
+        .replaceAll(RegExp(r'^-+|-+$'), '');
+    final shortSlug = slug.isEmpty
+        ? 'edit'
+        : (slug.length > 40 ? slug.substring(0, 40) : slug);
+    return 'admin-edit/$ts-$shortSlug';
+  }
+
+  String _shortBody(http.Response r) {
+    final body = r.body;
+    return body.length > 300 ? '${body.substring(0, 300)}...' : body;
+  }
+}

--- a/lib/update_service.dart
+++ b/lib/update_service.dart
@@ -29,7 +29,7 @@ class UpdateService {
   bool get hasLocalContent => _hasLocalContent;
   String? get localHtmlPath => _localHtmlPath;
 
-  static const int _manifestVersion = 16;
+  static const int _manifestVersion = 17;
 
   Future<void> initialize() async {
     try {
@@ -338,6 +338,35 @@ class UpdateService {
   String _gitBlobSha(List<int> bytes) {
     final header = utf8.encode('blob ${bytes.length}\x00');
     return sha1.convert([...header, ...bytes]).toString();
+  }
+
+  /// Writes [content] (the post-edit HTML) to the local copy of [relativePath]
+  /// (e.g. "Bereshit/1.html"), so the in-app WebView reflects the edit
+  /// immediately after a PR is opened, without waiting for the next
+  /// background sync to download the merged file from GitHub.
+  ///
+  /// If we don't have a local content directory yet (i.e. the app is
+  /// still serving from bundled assets), we initialize one by copying
+  /// the bundled assets first, then write over the edited file.
+  Future<bool> writeLocalAssetFile(String relativePath, String content) async {
+    try {
+      if (_localHtmlPath == null) {
+        print('[UpdateService] writeLocalAssetFile: no local path');
+        return false;
+      }
+      if (!_hasLocalContent) {
+        await _copyBundledAssets();
+        _hasLocalContent = true;
+      }
+      final localFile = File('${_localHtmlPath!}/$relativePath');
+      await localFile.parent.create(recursive: true);
+      await localFile.writeAsString(content);
+      print('[UpdateService] Wrote local edit to $relativePath (${content.length} bytes)');
+      return true;
+    } catch (e) {
+      print('[UpdateService] writeLocalAssetFile error: $e');
+      return false;
+    }
   }
 
   Future<void> clearLocalContent() async {

--- a/lib/update_service.dart
+++ b/lib/update_service.dart
@@ -29,7 +29,7 @@ class UpdateService {
   bool get hasLocalContent => _hasLocalContent;
   String? get localHtmlPath => _localHtmlPath;
 
-  static const int _manifestVersion = 17;
+  static const int _manifestVersion = 18;
 
   Future<void> initialize() async {
     try {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.5.2+5005
+version: 1.5.3+5006
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.5.1+5004
+version: 1.5.2+5005
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/scripts/inject_admin_assets.py
+++ b/scripts/inject_admin_assets.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""
+Inject the admin.css link and admin.js script tag into every
+HTML file under assets/html.
+
+Idempotent: running it twice does NOT duplicate the tags. It
+detects an existing reference to admin.css / admin.js and skips
+the file in that case.
+
+Usage:
+    python3 scripts/inject_admin_assets.py            # runs in CWD
+    python3 scripts/inject_admin_assets.py --dry-run
+
+The script is intentionally generic: it figures out the relative
+path to ./css/admin.css and ./js/admin.js for each HTML file
+based on its depth under assets/html (so files at the root use
+'css/...' and files inside Bereshit/ use '../css/...').
+"""
+
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+
+
+HTML_ROOT_HINT = os.path.join("assets", "html")
+
+
+def find_html_root(start: Path) -> Path:
+    """Find the assets/html folder by walking up from `start`."""
+    cur = start.resolve()
+    for _ in range(6):
+        candidate = cur / "assets" / "html"
+        if candidate.is_dir():
+            return candidate
+        cur = cur.parent
+    raise SystemExit(f"Could not find assets/html starting from {start}")
+
+
+def relative_prefix(html_file: Path, html_root: Path) -> str:
+    """Compute the '../' prefix needed to reach html_root from html_file's folder."""
+    depth = len(html_file.parent.resolve().relative_to(html_root.resolve()).parts)
+    return "../" * depth if depth else "./"
+
+
+HEAD_OPEN_RE = re.compile(r"<head\b[^>]*>", re.IGNORECASE)
+HTML_OPEN_RE = re.compile(r"<html\b[^>]*>", re.IGNORECASE)
+ADMIN_CSS_RE = re.compile(r"admin\.css", re.IGNORECASE)
+ADMIN_JS_RE = re.compile(r"admin\.js", re.IGNORECASE)
+
+
+def build_tags(prefix: str) -> str:
+    css = f"<link rel='stylesheet' type='text/css' href='{prefix}css/admin.css'>"
+    js = f"<script src='{prefix}js/admin.js'></script>"
+    return f"{css}{js}"
+
+
+def patch_file(path: Path, html_root: Path, dry_run: bool) -> str:
+    """Returns one of: 'patched', 'skipped-already', 'skipped-no-head', 'skipped-error'."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        text = path.read_text(encoding="latin-1")
+
+    if ADMIN_CSS_RE.search(text) and ADMIN_JS_RE.search(text):
+        return "skipped-already"
+
+    prefix = relative_prefix(path, html_root)
+    tags = build_tags(prefix)
+
+    head_match = HEAD_OPEN_RE.search(text)
+    if head_match:
+        insert_at = head_match.end()
+        new_text = text[:insert_at] + tags + text[insert_at:]
+    else:
+        # No <head>: inject right after <html...> or at the very top.
+        html_match = HTML_OPEN_RE.search(text)
+        if html_match:
+            insert_at = html_match.end()
+            new_text = text[:insert_at] + "<head>" + tags + "</head>" + text[insert_at:]
+        else:
+            new_text = "<head>" + tags + "</head>" + text
+
+    if not dry_run:
+        path.write_text(new_text, encoding="utf-8")
+    return "patched"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path.cwd(),
+                        help="Project root (defaults to CWD).")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Don't write files, just report.")
+    args = parser.parse_args()
+
+    html_root = find_html_root(args.root)
+    print(f"[inject_admin_assets] html root: {html_root}")
+
+    counts = {"patched": 0, "skipped-already": 0, "skipped-no-head": 0}
+    for path in sorted(html_root.rglob("*.html")):
+        result = patch_file(path, html_root, args.dry_run)
+        counts[result] = counts.get(result, 0) + 1
+        if result == "patched":
+            print(f"  + {path.relative_to(html_root)}")
+        elif result == "skipped-already":
+            pass  # quiet
+        else:
+            print(f"  ? {path.relative_to(html_root)} -> {result}")
+
+    print(f"[inject_admin_assets] done. {counts}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Restores the missing `lib/admin/` Dart sources (master currently does not compile without them), and adds three new admin-mode features:

1. **Preview before commit**: Submit PR flow now shows a fullscreen iframe (`srcdoc`) of the post-edit page so you can verify formatting before opening the PR.
2. **Clickable PR link**: PR success modal includes a clickable URL and an *Open in browser* button (uses `url_launcher` to open the PR on github.com).
3. **Apply edit locally**: After the PR is opened, the edited HTML is written to the local file under `<docs>/html_content/<filePath>` so the in-app WebView reflects the change immediately, without waiting for the next background sync.

## Other
- pubspec bumped to `1.5.2+5005`; adds `flutter_secure_storage` and `url_launcher`.
- UpdateService manifest version bumped to 17 to force existing installs to pick up the new admin.js.
- Adds `scripts/inject_admin_assets.py` for idempotently injecting the admin link/script tags into HTML.

## Test plan
- [ ] Install the new APK / AAB on a device.
- [ ] 5-tap top of screen, enter passphrase, verify admin toolbar appears.
- [ ] Edit some text, tap Submit PR, enter title.
- [ ] Verify preview iframe shows the edit with correct formatting.
- [ ] Tap *Looks good — submit*; verify PR is opened on GitHub.
- [ ] Verify the success modal shows a clickable link; tap *Open in browser*.
- [ ] Navigate away and back to the edited file; verify the local edit persists.
